### PR TITLE
Additional Participant Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ RKS_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n230703de230703de230703de\nb62b
 If successful, the app will print out your token and number of participants in the console, like so:
 
 ```
-Obtained access token:
+Obtained service access token:
   YOUR TOKEN HERE
 
 Total Participants: 5
 ```
 
-The access token is only valid for a few minutes, but you can copy/paste it into a REST query tool of your choice to try out advanced queries.
+The service access token is only valid for a few minutes, but you can copy/paste it into a REST query tool of your choice to try out advanced queries.
+
+You can also edit the code to specify a participant identifier and get a participant access token for that participant. This token is only needed for [MyDataHelps Embeddables](https://developer.mydatahelps.org/embeddables), and is useful for testing with the [MyDataHelps Starter Kit](https://github.com/CareEvolution/MyDataHelpsStarterKit). 
 
 ## Troubleshooting
 

--- a/quickstart.js
+++ b/quickstart.js
@@ -119,7 +119,7 @@ async function quickstart() {
       // NOTE: This piece is only necessary when using MyDataHelps Embeddables in a custom app. 
       // Most API use cases do NOT require a participant token.
       // Be sure to:
-      // 1. Use the internal ID field (from participant.id above) and NOT participant_identifier
+      // 1. Use the internal ID field (from participant.id above) and NOT participantIdentifier
       // 2. Request the correct scope(s) for your needs.
       const scopes = "Participant:read SurveyAnswers:read"
       const participantAccessToken = await getParticipantAccessToken(serviceAccessToken, participant.id, scopes);

--- a/quickstart.js
+++ b/quickstart.js
@@ -118,7 +118,9 @@ async function quickstart() {
 
       // NOTE: This piece is only necessary when using MyDataHelps Embeddables in a custom app. 
       // Most API use cases do NOT require a participant token.
-      // Be sure to request the correct scope(s) for your needs.
+      // Be sure to:
+      // 1. Use the internal ID field (from participant.id above) and NOT participant_identifier
+      // 2. Request the correct scope(s) for your needs.
       const scopes = "Participant:read SurveyAnswers:read"
       const participantAccessToken = await getParticipantAccessToken(serviceAccessToken, participant.id, scopes);
       console.log(`\nObtained participant access token for ${participant.id}: ${participantAccessToken}`);

--- a/quickstart.js
+++ b/quickstart.js
@@ -105,20 +105,23 @@ async function quickstart() {
 
   // Get a specific participant by identifier. We disable 'raiseError' here
   // so we can handle the 404 case ourselves.
-  const participantIdentifier = "PT-123";
-  url = `/api/v1/administration/projects/${rksProjectId}/participants/${participantIdentifier}`;
-  response = await getFromApi(serviceAccessToken, url, {}, false );
-  if (response.status === 404) {
-    console.log("\nParticipant not found.");
-  } else {
-    const participant = response.data;
-    console.log(`\nParticipant Found. ID: ${participant.id}`);
+  const participantIdentifier = "YOUR_PARTICIPANT_IDENTIFIER";
+  
+  if (participantIdentifier != "YOUR_PARTICIPANT_IDENTIFIER") {
+    url = `/api/v1/administration/projects/${rksProjectId}/participants/${participantIdentifier}`;
+    response = await getFromApi(serviceAccessToken, url, {}, false );
+    if (response.status === 404) {
+      console.log("\nParticipant not found.");
+    } else {
+      const participant = response.data;
+      console.log(`\nParticipant Found. ID: ${participant.id}`);
 
-    // NOTE: This piece is only necessary when using MyDataHelps Embeddables in a custom app. 
-    // Most API use cases do NOT require a participant token.
-    const scopes = "api user/*.read"
-    const participantAccessToken = await getParticipantAccessToken(serviceAccessToken, participant.id, scopes);
-    console.log(`\nParticipant access token obtained: ${participantAccessToken}`);
+      // NOTE: This piece is only necessary when using MyDataHelps Embeddables in a custom app. 
+      // Most API use cases do NOT require a participant token.
+      const scopes = "api user/*.read"
+      const participantAccessToken = await getParticipantAccessToken(serviceAccessToken, participant.id, scopes);
+      console.log(`\nObtained participant access token for ${participant.id}: ${participantAccessToken}`);
+    }
   }
 }
 

--- a/quickstart.js
+++ b/quickstart.js
@@ -105,7 +105,7 @@ async function quickstart() {
 
   // Get a specific participant by identifier. We disable 'raiseError' here
   // so we can handle the 404 case ourselves.
-  const participantIdentifier = "YOUR_PARTICIPANT_IDENTIFIER";
+  const participantIdentifier = "YOUR_PARTICIPANT_IDENTIFIER"
   
   if (participantIdentifier != "YOUR_PARTICIPANT_IDENTIFIER") {
     url = `/api/v1/administration/projects/${rksProjectId}/participants/${participantIdentifier}`;
@@ -118,7 +118,8 @@ async function quickstart() {
 
       // NOTE: This piece is only necessary when using MyDataHelps Embeddables in a custom app. 
       // Most API use cases do NOT require a participant token.
-      const scopes = "api user/*.read"
+      // Be sure to request the correct scope(s) for your needs.
+      const scopes = "Participant:read SurveyAnswers:read"
       const participantAccessToken = await getParticipantAccessToken(serviceAccessToken, participant.id, scopes);
       console.log(`\nObtained participant access token for ${participant.id}: ${participantAccessToken}`);
     }


### PR DESCRIPTION
## Overview

* Added examples for querying for a ppt and getting a ppt access token.
* Minor clarifications, such as being explicit about service access token naming and cleaning up the async calls.

## Security

REMINDER: All file contents are public.

- [X] I have ensured no secure credentials or sensitive information remain in code, metadata, comments, etc.
- [X] There are no temporary testing changes committed such as API base URLs, access tokens, print/log statements, etc.
- [X] These changes do not introduce any security risks, or any such risks have been properly mitigated.

Describe briefly what security risks you considered, why they don't apply, or how they've been mitigated.

Consider "Squash and merge" as needed to keep the commit history reasonable on `main`.

## Reviewers

Assign to the appropriate reviewer(s). Minimally, a second set of eyes is needed ensure no non-public information is published. Consider also including:
- Subject-matter experts
- Style/editing reviewers
- Others requested by the content owner